### PR TITLE
Fix right click for some specific external usb or bluetooth mouse

### DIFF
--- a/eclipse_projects/bVNC/src/com/iiordanov/bVNC/AbstractGestureInputHandler.java
+++ b/eclipse_projects/bVNC/src/com/iiordanov/bVNC/AbstractGestureInputHandler.java
@@ -214,7 +214,10 @@ abstract class AbstractGestureInputHandler extends GestureDetector.SimpleOnGestu
 		// If the mouse was moved.
 		case MotionEvent.ACTION_HOVER_MOVE:
 	    	vncCanvas.panToMouse();
-			return p.processPointerEvent(x, y, action, meta, false, false, false, false, 0);
+		if(bstate == MotionEvent.BUTTON_SECONDARY)
+	    		return p.processPointerEvent(x, y, action, meta, true, true, false, false, 0); 
+	    	else
+	    		return p.processPointerEvent(x, y, action, meta, false, false, false, false, 0);
 		}
 		
 		prevMouseOrStylusAction = action;


### PR DESCRIPTION
For a few external usb or bluetooth mouses, right click won't trigger MotionEvent.ACTION_DOWN or MotionEvent.ACTION_MOVE, but only MotionEvent.ACTION_HOVER_MOVE. So we need to check bstate in this case, to process the right click if necessary.
