### PR TITLE
Disables highlighting of canvas when focused.

### DIFF
--- a/bVNC/src/main/java/com/iiordanov/bVNC/RemoteCanvasActivity.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/RemoteCanvasActivity.java
@@ -250,6 +250,9 @@ public class RemoteCanvasActivity extends AppCompatActivity implements OnKeyList
 
         canvas = (RemoteCanvas) findViewById(R.id.canvas);
 
+	if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            canvas.setDefaultFocusHighlightEnabled(false);
+        }
         if (android.os.Build.VERSION.SDK_INT >= 9) {
             android.os.StrictMode.ThreadPolicy policy = new android.os.StrictMode.ThreadPolicy.Builder().permitAll().build();
             android.os.StrictMode.setThreadPolicy(policy);


### PR DESCRIPTION
Fixes "washed out colors" or removes "semi-transparent overlay" on Android 8.0+
https://developer.android.com/reference/android/view/View#setDefaultFocusHighlightEnabled(boolean)

Tested on Samsung Dex with ​this Termux am command: am start -a android.intent.action.VIEW -d vnc://com.iiordanov.bVNC.CONNECTION%3A1 -n com.iiordanov.bVNC/com.iiordanov.bVNC.RemoteCanvasActivity -f 268435456 -f 1342177