### PR TITLE
Fix for USB forwarding on Opaque Android 13

### DIFF
--- a/remoteClientLib/src/main/java/com/undatech/opaque/util/UsbDeviceManager.kt
+++ b/remoteClientLib/src/main/java/com/undatech/opaque/util/UsbDeviceManager.kt
@@ -70,8 +70,13 @@ class UsbDeviceManager(val context: Context, val usbEnabled: Boolean) {
         Log.i(TAG, "Requesting permissions for all USB devices")
         val d = this.getUnrequested()
         if (d != null) {
-            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val flags = if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
                 PendingIntent.FLAG_IMMUTABLE
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                // Special case for Android 13, because for some reasons FLAG_IMMUTABLE causes
+                // issues with USB forwarding.
+                // See https://github.com/iiordanov/remote-desktop-clients/issues/526
+                PendingIntent.FLAG_MUTABLE
             } else {
                 0
             };


### PR DESCRIPTION
Hi,

First, thank you for your amazing work on this project !

**TL; DR :** This is a fix for #526.

## Change Log

The issue arose because of a [specific commit](https://github.com/iiordanov/remote-desktop-clients/commit/3681e2d4ba03795a6d2acadaa27a516367413c2f) on Android 13, so I reverted the commit part by part to see where the problem was coming from.

Turns out it comes from the changes made to [`remoteClientLib/src/main/java/com/undatech/opaque/util/UsbDeviceManager.kt`](https://github.com/iiordanov/remote-desktop-clients/commit/3681e2d4ba03795a6d2acadaa27a516367413c2f#diff-b8202bd34d2b8fdb7db89851a30262fc3d3777f7730eacc666a39c4980c4a054). Why? I'm honestly not sure, I searched through change logs from Android 13 to 14, but could not find anything that would explain the problem.

Anyway, this change fixes the app on Android 13 while preserving the same behavior on Android 14 (I tested both). It simply

- Keeps the old behavior (before the problematic commit) on Android 13
- Keeps the new behavior (after the problematic commit) on Android 14

Please let me know if you would like anything changed in the PR.

Cheers !