### PR TITLE
Add option to build without Google dependencies

### DIFF
--- a/CustomVnc-app/build.gradle
+++ b/CustomVnc-app/build.gradle
@@ -20,6 +20,18 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withGoogle"]
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withoutGoogle"]
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/Opaque-app/build.gradle
+++ b/Opaque-app/build.gradle
@@ -20,6 +20,18 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withGoogle"]
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withoutGoogle"]
+        }
+    }
+
     sourceSets.main {
         java.srcDirs += 'src/main/java'
     }

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ Welcome screen, browsing to the remote-desktop-clients directory and selecting i
 
   - Build -> Make Project should now work.
 
+### Opting-out of Google dependencies
+
+To build without Google dependencies,
+
+1. Open the project in Android Studio
+2. In Android Studio menu, select Build -> Select Build Variant...
+3. In the Build Variants window, select the `withoutGoogleDebug` or `withoutGoogleRelease` variant
+for the module(s) you want to build.
+
 ## Custom Certificate Authority
 
 You can add custom CAs for aSPICE and Opaque in remoteClientLib/certificate_authorities/. They will be merged with the

--- a/aRDP-app/build.gradle
+++ b/aRDP-app/build.gradle
@@ -16,6 +16,18 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withGoogle"]
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withoutGoogle"]
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/aSPICE-app/build.gradle
+++ b/aSPICE-app/build.gradle
@@ -16,6 +16,18 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withGoogle"]
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withoutGoogle"]
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/bVNC-app/build.gradle
+++ b/bVNC-app/build.gradle
@@ -16,6 +16,18 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withGoogle"]
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withoutGoogle"]
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/bVNC/build.gradle
+++ b/bVNC/build.gradle
@@ -17,6 +17,16 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+        }
+    }
+
     packagingOptions {
         exclude 'lib/armeabi/libsqlcipher.so'
         exclude 'lib/mips64/libsqlcipher.so'
@@ -52,10 +62,10 @@ dependencies {
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation 'com.google.android.play:review:2.0.1'
-    implementation 'com.google.android.play:review-ktx:2.0.1'
+    withGoogleImplementation 'com.google.android.play:review:2.0.1'
+    withGoogleImplementation 'com.google.android.play:review-ktx:2.0.1'
     implementation project(path: ':common')
-    implementation 'com.google.android.gms:play-services-base:18.0.1'
+    withGoogleImplementation 'com.google.android.gms:play-services-base:18.0.1'
 }
 repositories {
     mavenCentral()

--- a/bVNC/src/main/java/com/iiordanov/bVNC/Utils.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/Utils.java
@@ -51,12 +51,6 @@ import android.widget.ScrollView;
 
 import com.antlersoft.android.contentxml.SqliteElement;
 import com.antlersoft.android.contentxml.SqliteElement.ReplaceStrategy;
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
-import com.google.android.gms.tasks.Task;
-import com.google.android.play.core.review.ReviewInfo;
-import com.google.android.play.core.review.ReviewManager;
-import com.google.android.play.core.review.ReviewManagerFactory;
 import com.undatech.opaque.AbstractDrawableData;
 import com.undatech.opaque.ConnectionSetupActivity;
 import com.undatech.remoteClientUi.R;
@@ -628,25 +622,6 @@ public class Utils {
         } catch (ActivityNotFoundException e) {
             Log.e(TAG, "startUriIntent: ActivityNotFoundException caught.");
         }
-    }
-
-    public static void showRateAppDialog(Activity activity) {
-        ReviewManager manager = ReviewManagerFactory.create(activity);
-        Task<ReviewInfo> request = manager.requestReviewFlow();
-        request.addOnCompleteListener(task -> {
-            GoogleApiAvailability apiAvailability = GoogleApiAvailability.getInstance();
-            if (apiAvailability.isGooglePlayServicesAvailable(activity) == ConnectionResult.SUCCESS) {
-                if (task.isSuccessful()) {
-                    ReviewInfo reviewInfo = task.getResult();
-                    Task<Void> flow = manager.launchReviewFlow(activity, reviewInfo);
-                    flow.addOnCompleteListener(completedTask -> {
-                        Log.d(TAG, "rateApp: Completed: " + completedTask.getResult());
-                    });
-                } else {
-                    Log.d(TAG, "rateApp: task is not successful");
-                }
-            }
-        });
     }
 
     public static void setClipboard(Context context, String url) {

--- a/bVNC/src/main/java/com/undatech/opaque/ConnectionGridActivity.java
+++ b/bVNC/src/main/java/com/undatech/opaque/ConnectionGridActivity.java
@@ -61,6 +61,7 @@ import com.iiordanov.bVNC.App;
 import com.iiordanov.bVNC.ConnectionBean;
 import com.iiordanov.bVNC.Constants;
 import com.iiordanov.bVNC.Database;
+import com.iiordanov.bVNC.GoogleUtils;
 import com.iiordanov.bVNC.RemoteCanvasActivity;
 import com.iiordanov.bVNC.Utils;
 import com.iiordanov.bVNC.dialogs.GetTextFragment;
@@ -591,7 +592,7 @@ public class ConnectionGridActivity extends FragmentActivity implements GetTextF
 
     public void rateApp(View item) {
         Log.d(TAG, "rateApp: Showing rate app functionality");
-        Utils.showRateAppDialog(this);
+        GoogleUtils.showRateAppDialog(this);
     }
 
     public void shareApp(View item) {

--- a/bVNC/src/withGoogle/java/com/iiordanov/bVNC/GoogleUtils.java
+++ b/bVNC/src/withGoogle/java/com/iiordanov/bVNC/GoogleUtils.java
@@ -1,0 +1,34 @@
+package com.iiordanov.bVNC;
+
+import android.app.Activity;
+import android.util.Log;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.tasks.Task;
+import com.google.android.play.core.review.ReviewInfo;
+import com.google.android.play.core.review.ReviewManager;
+import com.google.android.play.core.review.ReviewManagerFactory;
+
+public class GoogleUtils {
+    private final static String TAG = "GoogleUtils";
+
+    public static void showRateAppDialog(Activity activity) {
+        ReviewManager manager = ReviewManagerFactory.create(activity.getApplicationContext());
+        Task<ReviewInfo> request = manager.requestReviewFlow();
+        request.addOnCompleteListener(task -> {
+            GoogleApiAvailability apiAvailability = GoogleApiAvailability.getInstance();
+            if (apiAvailability.isGooglePlayServicesAvailable(activity) == ConnectionResult.SUCCESS) {
+                if (task.isSuccessful()) {
+                    ReviewInfo reviewInfo = task.getResult();
+                    Task<Void> flow = manager.launchReviewFlow(activity, reviewInfo);
+                    flow.addOnCompleteListener(completedTask -> {
+                        Log.d(TAG, "rateApp: Completed: " + completedTask.getResult());
+                    });
+                } else {
+                    Log.d(TAG, "rateApp: task is not successful");
+                }
+            }
+        });
+    }
+}

--- a/bVNC/src/withoutGoogle/java/com/iiordanov/bVNC/GoogleUtils.java
+++ b/bVNC/src/withoutGoogle/java/com/iiordanov/bVNC/GoogleUtils.java
@@ -1,0 +1,9 @@
+package com.iiordanov.bVNC;
+
+import android.app.Activity;
+
+public class GoogleUtils {
+    public static void showRateAppDialog(Activity activity) {
+
+    }
+}

--- a/freeaRDP-app/build.gradle
+++ b/freeaRDP-app/build.gradle
@@ -16,6 +16,18 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withGoogle"]
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withoutGoogle"]
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/freeaSPICE-app/build.gradle
+++ b/freeaSPICE-app/build.gradle
@@ -16,6 +16,18 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withGoogle"]
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withoutGoogle"]
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/freebVNC-app/build.gradle
+++ b/freebVNC-app/build.gradle
@@ -16,6 +16,18 @@ android {
         }
     }
 
+    flavorDimensions += "googleDependencies"
+    productFlavors {
+        withGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withGoogle"]
+        }
+        withoutGoogle {
+            dimension "googleDependencies"
+            matchingFallbacks ["withoutGoogle"]
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Hi,

**TL;DR :** This is a fix for #486.

## Change Log

I followed the instructions in [this comment](https://github.com/iiordanov/remote-desktop-clients/issues/300#issuecomment-1870631632) and used Gradle flavors so that it is easily configurable in Android Studio.

- Added two flavors and a flavor dimension to the `build.gradle` of `:bVNC`, to build it `withGoogle` or `withoutGoogle`.
- Created `bVNC/src/withGoogle/.../GoogleUtils.java` and `bVNC/src/withoutGoogle/.../GoogleUtils.java`, to isolate Google dependencies imports.
- Moved the only function that used Google deps, `showRateAppDialog`, into `GoogleUtils.java`. When building `withGoogle`, it works as before, but for `withoutGoogle` it simply does nothing for now (should it log something? Let me know).
- Removed Google deps imports from `bVNC/src/main/java/com/iiordanov/bVNC/Utils.java`. Removed the original declaration of `showRateAppDialog` as well.
- Changed the only reference to `showRateAppDialog` in `ConnectionGridActivity.java` to a reference to the new `GoogleUtils` class.
- Added flavors to the `build.gradle` file of the modules that use `:bVNC`, so that they know which flavor of `:bVNC` to use (otherwise it cannot be resolved when building).
- Added a sub-section to the `README` to tell how to build without Google dependencies.

I tried to avoid having two `GoogleUtils.java` files, but I had problems with the Google deps imports that caused errors when building without Google.

Now, if you would prefer to keep everything in `Utils.java`, I might be able to figure something out with reflection if that sounds good enough to you, or search for something else, but right now the only solution I found to keep everything in one file is reflection.

Please let me know if anything is unclear or if you would like anything changed in the PR.

Cheers !