### PR TITLE
Global setting to configure scroll sensitivity when using touch

### DIFF
--- a/bVNC/src/main/java/com/iiordanov/bVNC/Constants.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/Constants.java
@@ -186,6 +186,7 @@ public class Constants {
     public static final String doNotShowDesktopThumbnails = "doNotShowDesktopThumbnails";
     public static final String showOnlyConnectionNicknames = "showOnlyConnectionNicknames";
     public static final String softwareKeyboardType = "softwareKeyboardType";
+    public static final String scrollSensitivity = "scrollSensitivity";
     public static final String ACTION_USB_PERMISSION = "com.iiordanov.aSPICE.USB_PERMISSION";
     public static final int usbDeviceTimeout = 5000;
     public static final int usbDevicePermissionTimeout = 15000;

--- a/bVNC/src/main/java/com/iiordanov/bVNC/Constants.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/Constants.java
@@ -186,7 +186,7 @@ public class Constants {
     public static final String doNotShowDesktopThumbnails = "doNotShowDesktopThumbnails";
     public static final String showOnlyConnectionNicknames = "showOnlyConnectionNicknames";
     public static final String softwareKeyboardType = "softwareKeyboardType";
-    public static final String scrollSensitivity = "scrollSensitivity";
+    public static final String scrollSpeed = "scrollSpeed";
     public static final String ACTION_USB_PERMISSION = "com.iiordanov.aSPICE.USB_PERMISSION";
     public static final int usbDeviceTimeout = 5000;
     public static final int usbDevicePermissionTimeout = 15000;
@@ -198,6 +198,7 @@ public class Constants {
     public static final int CURSOR_FORCE_LOCAL = 1;
     public static final int CURSOR_FORCE_DISABLE = 2;
     public static volatile int DEFAULT_PROTOCOL_PORT = 5900;
+    public static final int DEFAULT_SCROLL_SPEED = 6;
 
     public static final String DEFAULT_VPN_URI_SCHEME = "vpn";
     /**

--- a/bVNC/src/main/java/com/iiordanov/bVNC/RemoteCanvasActivity.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/RemoteCanvasActivity.java
@@ -1134,7 +1134,7 @@ public class RemoteCanvasActivity extends AppCompatActivity implements
 
     int getScrollSensitivitySetting() {
         // SeekBar starts at 0, so add 1 to not have 0 sensitivity
-        return Utils.querySharedPreferencesInt(this, Constants.scrollSensitivity, 6) + 1;
+        return Utils.querySharedPreferencesInt(this, Constants.scrollSpeed, Constants.DEFAULT_SCROLL_SPEED) + 1;
     }
 
     @Override

--- a/bVNC/src/main/java/com/iiordanov/bVNC/RemoteCanvasActivity.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/RemoteCanvasActivity.java
@@ -1092,13 +1092,13 @@ public class RemoteCanvasActivity extends AppCompatActivity implements
             if (inputModeIds[i] == id) {
                 if (inputModeHandlers[i] == null) {
                     if (id == R.id.itemInputTouchPanZoomMouse) {
-                        inputModeHandlers[i] = new TouchInputHandlerDirectSwipePan(this, canvas, remoteConnection, App.debugLog);
+                        inputModeHandlers[i] = new TouchInputHandlerDirectSwipePan(this, canvas, remoteConnection, App.debugLog, getScrollSensitivitySetting());
                     } else if (id == R.id.itemInputDragPanZoomMouse) {
-                        inputModeHandlers[i] = new TouchInputHandlerDirectDragPan(this, canvas, remoteConnection, App.debugLog);
+                        inputModeHandlers[i] = new TouchInputHandlerDirectDragPan(this, canvas, remoteConnection, App.debugLog, getScrollSensitivitySetting());
                     } else if (id == R.id.itemInputTouchpad) {
-                        inputModeHandlers[i] = new TouchInputHandlerTouchpad(this, canvas, remoteConnection, App.debugLog);
+                        inputModeHandlers[i] = new TouchInputHandlerTouchpad(this, canvas, remoteConnection, App.debugLog, getScrollSensitivitySetting());
                     } else if (id == R.id.itemInputSingleHanded) {
-                        inputModeHandlers[i] = new TouchInputHandlerSingleHanded(this, canvas, remoteConnection, App.debugLog);
+                        inputModeHandlers[i] = new TouchInputHandlerSingleHanded(this, canvas, remoteConnection, App.debugLog, getScrollSensitivitySetting());
                     } else {
                         throw new IllegalStateException("Unexpected value: " + id);
                     }
@@ -1130,6 +1130,11 @@ public class RemoteCanvasActivity extends AppCompatActivity implements
                 return id;
         }
         return R.id.itemInputTouchPanZoomMouse;
+    }
+
+    int getScrollSensitivitySetting() {
+        // SeekBar starts at 0, so add 1 to not have 0 sensitivity
+        return Utils.querySharedPreferencesInt(this, Constants.scrollSensitivity, 6) + 1;
     }
 
     @Override

--- a/bVNC/src/main/java/com/iiordanov/bVNC/Utils.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/Utils.java
@@ -390,6 +390,15 @@ public class Utils {
         return result;
     }
 
+    public static int querySharedPreferencesInt(Context context, String key, int dftValue) {
+        int result = dftValue;
+        if (context != null) {
+            SharedPreferences sp = context.getSharedPreferences(Constants.generalSettingsTag, Context.MODE_PRIVATE);
+            result = sp.getInt(key, dftValue);
+        }
+        return result;
+    }
+
     public static void setSharedPreferenceString(Context context, String key, String value) {
         if (context != null) {
             SharedPreferences sp = context.getSharedPreferences(Constants.generalSettingsTag, Context.MODE_PRIVATE);

--- a/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerDirectDragPan.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerDirectDragPan.java
@@ -33,8 +33,9 @@ public class TouchInputHandlerDirectDragPan extends TouchInputHandlerGeneric {
     static final String TAG = "InputHandlerDirectDragPan";
 
     public TouchInputHandlerDirectDragPan(RemoteCanvasActivity activity, RemoteCanvas canvas,
-                                          InputCarriable remoteInput, boolean debugLogging) {
-        super(activity, canvas, remoteInput, debugLogging);
+                                          InputCarriable remoteInput, boolean debugLogging,
+                                          int swipeSpeed) {
+        super(activity, canvas, remoteInput, debugLogging, swipeSpeed);
     }
 
     /*

--- a/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerDirectSwipePan.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerDirectSwipePan.java
@@ -33,8 +33,9 @@ public class TouchInputHandlerDirectSwipePan extends TouchInputHandlerGeneric {
     static final String TAG = "InputHandlerDirectSwipePan";
 
     public TouchInputHandlerDirectSwipePan(RemoteCanvasActivity activity, RemoteCanvas canvas,
-                                           InputCarriable remoteInput, boolean debugLogging) {
-        super(activity, canvas, remoteInput, debugLogging);
+                                           InputCarriable remoteInput, boolean debugLogging,
+                                           int swipeSpeed) {
+        super(activity, canvas, remoteInput, debugLogging, swipeSpeed);
     }
 
     /*

--- a/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerGeneric.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerGeneric.java
@@ -40,7 +40,7 @@ abstract class TouchInputHandlerGeneric extends GestureDetector.SimpleOnGestureL
         implements TouchInputHandler, ScaleGestureDetector.OnScaleGestureListener {
     private static final String TAG = "InputHandlerGeneric";
     protected final boolean debugLogging;
-    final int maxSwipeSpeed = 7;
+    int maxSwipeSpeed = 1;
     // If swipe events are registered once every baseSwipeTime miliseconds, then
     // swipeSpeed will be one. If more often, swipe-speed goes up, if less, down.
     final long baseSwipeTime = 400;
@@ -106,11 +106,12 @@ abstract class TouchInputHandlerGeneric extends GestureDetector.SimpleOnGestureL
     Queue<Float> distYQueue;
 
     TouchInputHandlerGeneric(RemoteCanvasActivity activity, RemoteCanvas canvas, InputCarriable remoteInput,
-                             boolean debugLogging) {
+                             boolean debugLogging, int swipeSpeed) {
         this.activity = activity;
         this.canvas = canvas;
         this.remoteInput = remoteInput;
         this.debugLogging = debugLogging;
+        this.maxSwipeSpeed = swipeSpeed;
 
         // TODO: Implement this
         useDpadAsArrows = true; //activity.getUseDpadAsArrows();

--- a/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerSingleHanded.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerSingleHanded.java
@@ -47,8 +47,9 @@ public class TouchInputHandlerSingleHanded extends TouchInputHandlerDirectSwipeP
     private boolean needInitPan;
 
     public TouchInputHandlerSingleHanded(RemoteCanvasActivity activity, RemoteCanvas canvas,
-                                         InputCarriable remoteInput, boolean debugLogging) {
-        super(activity, canvas, remoteInput, debugLogging);
+                                         InputCarriable remoteInput, boolean debugLogging,
+                                         int swipeSpeed) {
+        super(activity, canvas, remoteInput, debugLogging, swipeSpeed);
         initializeButtons();
     }
 

--- a/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerTouchpad.java
+++ b/bVNC/src/main/java/com/iiordanov/bVNC/input/TouchInputHandlerTouchpad.java
@@ -33,8 +33,9 @@ public class TouchInputHandlerTouchpad extends TouchInputHandlerGeneric {
     static final String TAG = "InputHandlerTouchpad";
 
     public TouchInputHandlerTouchpad(RemoteCanvasActivity activity, RemoteCanvas canvas,
-                                     InputCarriable remoteInput, boolean debugLogging) {
-        super(activity, canvas, remoteInput, debugLogging);
+                                     InputCarriable remoteInput, boolean debugLogging,
+                                     int swipeSpeed) {
+        super(activity, canvas, remoteInput, debugLogging, swipeSpeed);
     }
 
     /*

--- a/bVNC/src/main/res/values/strings.xml
+++ b/bVNC/src/main/res/values/strings.xml
@@ -907,5 +907,5 @@ Below that is where you configure your connection.
     <string name="no_application_to_handle_vpn">This connection is set to launch VPN via an external app. You need to install an app like Morpheusly to launch it.</string>
     <string name="vnc_viewer_started">VNC Viewer started</string>
     <string name="enable_gateway">Enable Gateway</string>
-    <string name="scroll_sensitivity">Touch Scroll Sensitivity</string>
+    <string name="scroll_speed">Touch Scroll Speed</string>
 </resources>

--- a/bVNC/src/main/res/values/strings.xml
+++ b/bVNC/src/main/res/values/strings.xml
@@ -907,4 +907,5 @@ Below that is where you configure your connection.
     <string name="no_application_to_handle_vpn">This connection is set to launch VPN via an external app. You need to install an app like Morpheusly to launch it.</string>
     <string name="vnc_viewer_started">VNC Viewer started</string>
     <string name="enable_gateway">Enable Gateway</string>
+    <string name="scroll_sensitivity">Touch Scroll Sensitivity</string>
 </resources>

--- a/bVNC/src/main/res/xml/global_preferences.xml
+++ b/bVNC/src/main/res/xml/global_preferences.xml
@@ -34,4 +34,9 @@
         android:entryValues="@array/pref_keyboard_type_option_values"
         android:key="softwareKeyboardType"
         android:title="@string/keyboard_type" />
+    <SeekBarPreference
+        android:defaultValue="6"
+        android:max="9"
+        android:key="scrollSensitivity"
+        android:title="@string/scroll_sensitivity" />
 </PreferenceScreen>

--- a/bVNC/src/main/res/xml/global_preferences.xml
+++ b/bVNC/src/main/res/xml/global_preferences.xml
@@ -37,6 +37,6 @@
     <SeekBarPreference
         android:defaultValue="6"
         android:max="9"
-        android:key="scrollSensitivity"
-        android:title="@string/scroll_sensitivity" />
+        android:key="scrollSpeed"
+        android:title="@string/scroll_speed" />
 </PreferenceScreen>


### PR DESCRIPTION
Adds a global setting to configure the scroll sensitivity from 1 to 10 because different devices and servers treat the scrolling action differently.

### Testing
Device: Samsung A25, Android 14
App: bVNC pro
Server: tigervnc on Ubuntu 20.04

<img width="205" alt="Screenshot 2024-10-22 at 10 59 22" src="https://github.com/user-attachments/assets/44036a83-b961-49bd-8105-88116a4bb2e9">
