### PR TITLE
MOR-998 Update dependencies

### DIFF
--- a/bVNC/build.gradle
+++ b/bVNC/build.gradle
@@ -21,6 +21,7 @@ android {
         exclude 'lib/armeabi/libsqlcipher.so'
         exclude 'lib/mips64/libsqlcipher.so'
         exclude 'lib/mips/libsqlcipher.so'
+        exclude 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'
     }
 
     useLibrary 'org.apache.http.legacy'
@@ -39,8 +40,8 @@ dependencies {
     implementation files('libs/com.antlersoft.android.contentxml.jar')
     implementation files('libs/com.antlersoft.android.db.jar')
     // Current version of bVNC is built with bouncycastle with DH anon ciphers enabled. See https://github.com/iiordanov/bc-java
-    //implementation files("libs/bctls-jdk18on-1.70.jar")
-    implementation group: 'org.bouncycastle', name: 'bctls-jdk15on', version: '1.70'
+    //implementation files("libs/bctls-jdk18on-1.70.jar")  // This wants updating to 1.80 when https://github.com/bcgit/bc-java/issues/2057 is happy.
+    implementation group: 'org.bouncycastle', name: 'bctls-jdk18on', version: '1.80'
     implementation group: 'androidx.appcompat', name: 'appcompat', version: '1.4.1'
     implementation group: 'androidx.legacy', name: 'legacy-support-v4', version: '1.0.0'
     implementation group: 'androidx.vectordrawable', name: 'vectordrawable', version: '1.1.0'

--- a/bVNC/build.gradle
+++ b/bVNC/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation group: 'androidx.preference', name: 'preference-ktx', version: '1.2.0'
     implementation 'net.zetetic:android-database-sqlcipher:4.5.1@aar'
     implementation "androidx.sqlite:sqlite-ktx:2.2.0"
-    implementation group: 'org.yaml', name: 'snakeyaml', version: '1.23'
+    implementation group: 'org.yaml', name: 'snakeyaml', version: '2.4'
     implementation 'org.apache.httpcomponents:httpcore:4.4.10'
     implementation "com.github.luben:zstd-jni:1.4.3-1@aar"
     implementation "androidx.core:core-ktx:1.7.0"

--- a/freebVNC-app/build.gradle
+++ b/freebVNC-app/build.gradle
@@ -16,6 +16,10 @@ android {
         }
     }
 
+    packagingOptions {
+        exclude 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/pubkeyGenerator/build.gradle
+++ b/pubkeyGenerator/build.gradle
@@ -14,6 +14,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+
+    packagingOptions {
+        exclude 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
@@ -35,8 +40,8 @@ apply plugin: "com.google.osdetector"
 
 dependencies {
     api 'org.connectbot:sshlib:2.2.23'
-    implementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
-    implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.70'
+    implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.80'
+    implementation group: 'org.bouncycastle', name: 'bcpkix-jdk18on', version: '1.80'
     api 'net.vrallev.ecc:ecc-25519-java:1.0.3'
     api 'io.moatwel.crypto:eddsa:0.8.1'
     api group: 'net.i2p.crypto', name: 'eddsa', version: '0.3.0'


### PR DESCRIPTION
Fixes #623 

Note: Until the bc-java issue mentioned in the comment is fixed, at least one part of bc-java will need to be kept on an older release when compiling the pro version, to avoid breaking anon-DH (which will affect vino).
However, this at least gets the open source clients up to date sooner without breaking functionality for them.