### PR TITLE
Enable AAC audio negotiation on RDP

### DIFF
--- a/remoteClientLib/jni/libs/22_freerdp_enable_dsp_ffmpeg_for_aac_audio.patch
+++ b/remoteClientLib/jni/libs/22_freerdp_enable_dsp_ffmpeg_for_aac_audio.patch
@@ -1,0 +1,12 @@
+diff --git a/scripts/android-build-freerdp.sh b/scripts/android-build-freerdp.sh
+--- a/scripts/android-build-freerdp.sh
++++ b/scripts/android-build-freerdp.sh
+@@ -151,7 +151,7 @@
+ 				--tag $FFMPEG_TAG \
+ 				--hash $FFMPEG_HASH
+ 		fi
+-		CMAKE_CMD_ARGS="$CMAKE_CMD_ARGS -DWITH_FFMPEG=ON -DWITH_SWCALE=ON"
++		CMAKE_CMD_ARGS="$CMAKE_CMD_ARGS -DWITH_FFMPEG=ON -DWITH_SWCALE=ON -DWITH_DSP_FFMPEG=ON"
+ 	else
+ 		CMAKE_CMD_ARGS="$CMAKE_CMD_ARGS -DWITH_FFMPEG=OFF"
+ 	fi

--- a/remoteClientLib/jni/libs/23_freerdp_slim_ffmpeg_to_codecs_freerdp_uses.patch
+++ b/remoteClientLib/jni/libs/23_freerdp_slim_ffmpeg_to_codecs_freerdp_uses.patch
@@ -1,0 +1,18 @@
+diff --git a/scripts/android-build-ffmpeg.sh b/scripts/android-build-ffmpeg.sh
+--- a/scripts/android-build-ffmpeg.sh
++++ b/scripts/android-build-ffmpeg.sh
+@@ -125,8 +125,12 @@
+         --enable-pic \
+         --enable-jni --enable-mediacodec \
+         --enable-shared \
+-        --disable-stripping \
+-        --disable-programs --disable-doc --disable-avdevice --disable-avfilter --disable-avformat
++        --enable-stripping \
++        --disable-programs --disable-doc --disable-avdevice --disable-avfilter --disable-avformat \
++        --disable-everything \
++        --enable-decoder=aac,h264,gsm_ms,g723_1,adpcm_ms,adpcm_ima_oki,pcm_u8,pcm_u16le,pcm_s16le,pcm_alaw,pcm_mulaw \
++        --enable-encoder=aac,g723_1,adpcm_ms,pcm_u8,pcm_u16le,pcm_s16le,pcm_alaw,pcm_mulaw \
++        --enable-parser=aac,h264
+
+     common_run make clean
+     common_run make -j


### PR DESCRIPTION
# Summary
Enables the AAC audio decoding capability so that clients with a weak hardware can process the audio without lags.

# Background
I was trying out aRDP's audio support on an old Android 7 tablet connected  to a gnome-remote-desktop RDP server. However, whenever I  played YouTube videos or any kind of sounds on the remote machine, the incoming audio was very choppy and difficult to hear clearly.

gnome-remote-desktop's log showed that the client only negotiated with raw PCM audio:
```
[RDP.AUDIO_PLAYBACK] Client Formats: [AAC: false, Opus: false, PCM: true]
```
...which obviously takes way too much network bandwidth for a weak device.

# The Fix
Even though the dependency build already includes `WITH_FFMPEG=1` to compile and ship FFmpeg, [dsp.c](https://github.com/FreeRDP/FreeRDP/blob/master/libfreerdp/codec/dsp.c) in FreeRDP has another flag that prevents audio codecs from actually being used. (`WITH_DSP_FFMPEG`)

This PR passes `-DWITH_DSP_FFMPEG=ON` inside `android-build-freerdp.sh` to actually enable FFmpeg audio codes.

The updated patch has been tested on a gnome-remote-desktop session and confirmed that the client now reports the AAC capability correctly:
```
[RDP.AUDIO_PLAYBACK] Client Formats: [AAC: true,  Opus: false, PCM: true]
```

This PR also includes an additional patch to slim the shipped FFmpeg libraries since enabling `WITH_DSP_FFMPEG` makes it include libavcodec.